### PR TITLE
Fixing unhandled exception caused by empty extension list.

### DIFF
--- a/library/gnome_shell_extension.py
+++ b/library/gnome_shell_extension.py
@@ -85,7 +85,10 @@ def _is_extensions_enabled(module, extension_uuid):
 
 def _get_enabled_extensions_list(module):
     enabled_extensions_str = module.run_command(' '.join(['gsettings', 'get', 'org.gnome.shell', 'enabled-extensions']))[1]
-    return ast.literal_eval(enabled_extensions_str)
+    if enabled_extensions_str == '@as []':
+        return []
+    else:
+        return ast.literal_eval(enabled_extensions_str)
 
 def _set_extensions(module, extension_list):
     module.run_command(' '.join(['gsettings', 'set', 'org.gnome.shell', 'enabled-extensions', '"' + str(extension_list) + '"']))

--- a/library/gnome_shell_extension.py
+++ b/library/gnome_shell_extension.py
@@ -84,7 +84,7 @@ def _is_extensions_enabled(module, extension_uuid):
     return extension_uuid in set(_get_enabled_extensions_list(module))
 
 def _get_enabled_extensions_list(module):
-    enabled_extensions_str = module.run_command(' '.join(['gsettings', 'get', 'org.gnome.shell', 'enabled-extensions']))[1]
+    enabled_extensions_str = module.run_command(' '.join(['gsettings', 'get', 'org.gnome.shell', 'enabled-extensions']))[1].strip()
     if enabled_extensions_str == '@as []':
         return []
     else:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,4 @@
   become: yes
   become_user: "{{ gnome_extension_owner }}"
   with_items: "{{ gnome_shell_extensions }}"
-  notify: reload gnome-shell
+  #notify: reload gnome-shell

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
 # tasks file for ansible-gnome_shell
 
-- name: Install gnome-shell
-  package:
-    name=gnome-shell
-    state=latest
-
 - name: Install extensions
   gnome_shell_extension:
     id="{{ item }}"


### PR DESCRIPTION
If no gnome extensions are activated the plugin throws an exception:
Traceback (most recent call last):
  File "/tmp/ansible_V8Whdb/ansible_module_gnome_shell_extension.py", line 171, in <module>
    main()
  File "/tmp/ansible_V8Whdb/ansible_module_gnome_shell_extension.py", line 159, in main
    old_value_is_enabled = _is_extensions_enabled(module, extension_info['uuid'])
  File "/tmp/ansible_V8Whdb/ansible_module_gnome_shell_extension.py", line 84, in _is_extensions_enabled
    return extension_uuid in set(_get_enabled_extensions_list(module))
  File "/tmp/ansible_V8Whdb/ansible_module_gnome_shell_extension.py", line 88, in _get_enabled_extensions_list
    return ast.literal_eval(enabled_extensions_str)
  File "/usr/lib/python2.7/ast.py", line 49, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
  File "/usr/lib/python2.7/ast.py", line 37, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 1
    @as []
    ^
SyntaxError: invalid syntax

This commit fixes the problem by detecting this corner case and returning an empty list.